### PR TITLE
Change moduleResolution from node to bundler

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "declaration": true,
     "outDir": "./dist",
     "strict": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
see:
- https://speakerdeck.com/uhyo/tsconfig-dot-jsonnoshe-ding-wojian-zhi-sou-hurontoendoxiang-ke-2024xia?slide=10
- https://zenn.dev/link/comments/6fd00fb623806c

"bundler" option allows us to import module without extension (e.g., we can write `import "foo"` instead of `import "foo.ts"`)